### PR TITLE
save validation reports for 400, 413, 422 status codes from validator api

### DIFF
--- a/src/library/db.py
+++ b/src/library/db.py
@@ -561,7 +561,7 @@ def updateValidationState(conn, doc_id, doc_hash, doc_url, state, report):
             UPDATE SET report = %(report)s,
                 valid = %(valid)s
             WHERE validation.document_hash=%(doc_hash)s;
-        UPDATE document SET validation=%(doc_hash)s, validation_api_error=null WHERE hash=%(doc_hash)s;
+        UPDATE document SET validation=%(doc_hash)s WHERE hash=%(doc_hash)s;
         """
 
     data = {


### PR DESCRIPTION
[Trello](https://trello.com/c/UzI3lNUX)

Previously we skipped saving validation reports for any 4xx response from the validator API

Now, we save validation reports for status codes 400, 422, 413 as they are ones we expect to get from the validator api when a file is not xml, not iati, or has schema errors, etc.﻿
