### PR TITLE
exclude organisation files from flattening

### DIFF
--- a/src/library/db.py
+++ b/src/library/db.py
@@ -178,7 +178,7 @@ def getUnflattenedDatasets(conn):
     WHERE doc.downloaded is not null 
     AND doc.flatten_start is Null
     AND val.valid = true
-    AND val.report ->> 'fileType' != 'iati-organisations'
+    AND val.report ->> 'fileType' = 'iati-activities'
     ORDER BY downloaded
     """
     cur.execute(sql)    

--- a/src/library/db.py
+++ b/src/library/db.py
@@ -178,6 +178,7 @@ def getUnflattenedDatasets(conn):
     WHERE doc.downloaded is not null 
     AND doc.flatten_start is Null
     AND val.valid = true
+    AND val.report ->> 'fileType' != 'iati-organisations'
     ORDER BY downloaded
     """
     cur.execute(sql)    


### PR DESCRIPTION
- Previously the refresher-flatten would attempt to flatten iati-organisations files.
- Now, `AND val.report ->> 'fileType' != 'iati-organisations'` has been added to the query selecting files to flatten to exclude org files from flattening.﻿
