### PR TITLE
log download error for undetectable charset, rather than downloading

### DIFF
--- a/src/library/refresher.py
+++ b/src/library/refresher.py
@@ -246,6 +246,9 @@ def download_chunk(chunk, blob_service_client, datasets):
                 try:
                     detect_result = chardet.detect(download_xml)
                     charset = detect_result['encoding']
+                    # log error for undetectable charset, prevent PDFs from being downloaded to Unified Platform
+                    if charset is None:
+                        db.updateFileAsDownloadError(conn, id, 0 )
                 except:
                     charset = 'UTF-8'
                 blob_client.upload_blob(download_xml, overwrite=True, encoding=charset)


### PR DESCRIPTION
[Trello](https://trello.com/c/fple96HX)

Previously, if we couldn't detect a charset for a file we would still download it into the unified platform, which caused files like PDFs to be present in the Unified Platform.
Now, if the result of trying to detect a charset of a file is 'None' we log a download error into the Unified Platform DB, and it's excluded from further checks (e.g. validation)

Note that we are seperately pursuing an enhancement to the Registry that would only allow xml files to be included in the registry.﻿
