### PR TITLE
Don't validate docs with download errors

### DIFF
--- a/src/library/db.py
+++ b/src/library/db.py
@@ -153,7 +153,7 @@ def getUnvalidatedDatasets(conn):
     sql = """
     SELECT hash, downloaded, id, url, validation_api_error, publisher
     FROM document 
-    WHERE downloaded is not null AND (validation is Null OR regenerate_validation_report is True) 
+    WHERE downloaded is not null AND download_error is not null AND (validation is Null OR regenerate_validation_report is True) 
     ORDER BY regenerate_validation_report DESC, downloaded
     """
     cur.execute(sql)    

--- a/src/library/db.py
+++ b/src/library/db.py
@@ -466,7 +466,7 @@ def resetFailedFlattens(conn):
 def updateFileAsDownloaded(conn, id):
     cur = conn.cursor()
 
-    sql="UPDATE document SET downloaded = %(dt)s WHERE id = %(id)s"
+    sql="UPDATE document SET downloaded = %(dt)s, download_error = null WHERE id = %(id)s"
 
     date = datetime.now()
 

--- a/src/library/db.py
+++ b/src/library/db.py
@@ -153,7 +153,7 @@ def getUnvalidatedDatasets(conn):
     sql = """
     SELECT hash, downloaded, id, url, validation_api_error, publisher
     FROM document 
-    WHERE downloaded is not null AND download_error is not null AND (validation is Null OR regenerate_validation_report is True) 
+    WHERE downloaded is not null AND download_error is null AND (validation is Null OR regenerate_validation_report is True) 
     ORDER BY regenerate_validation_report DESC, downloaded
     """
     cur.execute(sql)    


### PR DESCRIPTION
- set download error to null when updating file as successfully downloaded
- don't try to validate documents with download errors

[Trello](https://trello.com/c/fple96HX)