### PR TITLE
chore/slim docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.8-slim-bullseye
+RUN apt-get update && apt install -y \
+    gcc \ 
+    libpq-dev
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.6.20
 chardet==3.0.4
 idna==2.10
-psycopg2-binary==2.8.6
+psycopg2==2.8.6
 python-utils==2.4.0
 requests==2.24.0
 six==1.15.0


### PR DESCRIPTION
[Trello](https://trello.com/c/t9m7XSyQ)
- reduce docker image size with slim-bullseye
- slim-bullseye no psycopg2-binary
