### PR TITLE
 Increase RAM in refresh stage

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -18,7 +18,7 @@ properties: # Properties of container group
       properties: # Properties of an instance
         resources: # Resource requirements of the instance
           requests:
-            memoryInGB: 2
+            memoryInGB: 4
             cpu: 0.5
         image: '#IMAGE_NAME#' # Container image used to create the instance
         command:


### PR DESCRIPTION
Several large files were causing spikes in chardet memory usage. This caused the download_chunk thread to crash with no resolution written to logs or DB. Next time it looped around, it would try the same file again and crash again.