### PR TITLE
Change where Solr deletion happens; change db migration detection; & misc

### DIFF
--- a/src/constants/version.py
+++ b/src/constants/version.py
@@ -1,1 +1,1 @@
-__version__ = {'number': "0.1.24", 'migration': 24}
+__version__ = {'number': "0.1.24", 'migration': 25}

--- a/src/library/refresher.py
+++ b/src/library/refresher.py
@@ -168,8 +168,7 @@ def clean_datasets(stale_datasets, changed_datasets):
                            file_id + ' and hash: ' + file_hash)
 
     # clean up source xml and solr for both stale and changed datasets
-    combined_datasets_toclean = stale_datasets + changed_datasets
-    if len(combined_datasets_toclean) > 0:
+    if len(stale_datasets) > 0 or len(changed_datasets) > 0:
         logger.info('Removing ' + str(len(stale_datasets)) + ' stale and ' +
                     str(len(changed_datasets)) + ' changed documents')
 
@@ -232,6 +231,9 @@ def clean_datasets(stale_datasets, changed_datasets):
                     except:
                         logger.error('Failed to remove stale docs from solr with hash: ' +
                                      file_hash + ' and id: ' + file_id + ' from core with name ' + core_name)
+                # Maybe we should clean up the last_solrize_end field here, as they are now gone?
+                # However, we don't have to as if you look at how clean_datasets is called,
+                #   in each case right afterwards the rows are removed from the DB anyway.
             except Exception as e:
                 logger.error(
                     'Unknown error occurred while attempting to remove stale document ID {} from Source and SOLR'.format(file_id))
@@ -253,14 +255,10 @@ def clean_datasets(stale_datasets, changed_datasets):
                     clean_containers_by_id(blob_service_client, file_id, containers=[
                                            config['CLEAN_CONTAINER_NAME']])
 
-                # remove from all solr collections
-                for core_name in solr_cores:
-                    try:
-                        solr_cores[core_name].delete(
-                            q='iati_activities_document_id:' + file_id)
-                    except:
-                        logger.warn('Failed to remove changed docs from solr with hash: ' +
-                                    file_hash + ' and id: ' + file_id + ' from core with name ' + core_name)
+                # Don't remove from any solr collections!
+                # We want old data to stay in the system until new data is ready to be put in Solr.
+                # The Solrize stage will delete the old data from Solr.
+
             except Exception as e:
                 logger.error(
                     'Unknown error occurred while attempting to remove changed document ID {} from Source and SOLR'.format(file_id))

--- a/src/migrations/mig_25.py
+++ b/src/migrations/mig_25.py
@@ -1,0 +1,7 @@
+upgrade = """
+ALTER TABLE public.document ADD COLUMN last_solrize_end timestamp without time zone;
+UPDATE public.document SET last_solrize_end = solrize_end WHERE last_solrize_end IS NULL;
+"""
+downgrade = """
+ALTER TABLE public.document DROP COLUMN last_solrize_end;
+"""


### PR DESCRIPTION

Only delete changed data from Solr just before adding in solrise stage
 https://iaticonnect.org/group/9/topic/proposed-update-iati-datastore 
New DB column to track if data is in Solr or not

Database Migrations now run on migration var from src/constants/version.py only 
https://github.com/IATI/refresher/issues/273
This removes need to make sure number var there moves in sync with migrations. 
Also fixes bug in isUpgrade(fromVersion, toVersion) by scrapping function entirely. 
Previously isUpgrade("1.1.1", "0.2.0") would return True 
Not scrapping number var yet, as that is stored in DB and may be used elsewhere. It is also used in a user agent string.
(That GitHub issue can remain open to look at that later.)

Also remove combined_datasets_toclean var - it is only used once and we don't need to copy what might be large data sets