### PR TITLE
Increase RAM in flatten stage

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -165,7 +165,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 0.8
+            memoryInGB: 4
             cpu: 0.1
         image: '#IMAGE_NAME#'
         command:


### PR DESCRIPTION
A large file was causing spikes in chardet memory usage. This caused the thread to crash
Next time it looped around, it would try the same file again and crash again.

Similiar to 6791dc40f6f9ab52253dc6dc8cb5125b47cbbcfa And a2844ece9f5f12a547fdf077a25810448593fe05