### PR TITLE
Change RAM in flatten stage

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -165,7 +165,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 4
+            memoryInGB: 3.5
             cpu: 0.1
         image: '#IMAGE_NAME#'
         command:


### PR DESCRIPTION
Setting 4GB puts it above 16GB limit for container instance 
Change RAM so within limit
https://learn.microsoft.com/en-us/azure/container-instances/container-instances-resource-and-quota-limits#linux-container-groups

Increased to 4GB in 615d500ae480e0cc3057f342f828be64b481561a