### PR TITLE
Edgecase XML file for lakify

### DIFF
--- a/src/tests/fixtures_lakify_recursive_json_nest/edgecase.expected.json
+++ b/src/tests/fixtures_lakify_recursive_json_nest/edgecase.expected.json
@@ -1,0 +1,56 @@
+{
+  "iati-activity": [
+    {
+      "PI()": [
+        {
+          "text()": "version=\"1.0\""
+        }
+      ],
+      "comment()": [
+        {
+          "text()": "Test floating text"
+        },
+        {
+          "text()": "Test blank attribute"
+        },
+        {
+          "text()": "Test comment"
+        },
+        {
+          "text()": "Comment"
+        },
+        {
+          "text()": "Test processing instruction"
+        },
+        {
+          "text()": "Test self-closing tag"
+        },
+        {
+          "text()": "Test namespace with xmlns url"
+        },
+        {
+          "text()": "Test namespace without xmlns url"
+        }
+      ],
+      "iati-identifier": [
+        {
+          "@attribute": "",
+          "text()": "ACT-1"
+        }
+      ],
+      "sida:title": [
+        {
+          "text()": "Tanzania 2020-2024"
+        }
+      ],
+      "transaction": [
+        {}
+      ],
+      "{http://foreignassistance.gov/iati#}treasury-main-account": [
+        {
+          "@code": "95"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tests/fixtures_lakify_recursive_json_nest/edgecase.input.xml
+++ b/src/tests/fixtures_lakify_recursive_json_nest/edgecase.input.xml
@@ -1,0 +1,18 @@
+<iati-activities xmlns:usg="http://foreignassistance.gov/iati#">
+    <iati-activity>
+        <!--Test floating text-->
+        Floating text
+        <!--Test blank attribute-->
+        <iati-identifier attribute=''>ACT-1</iati-identifier>
+        <!--Test comment-->
+        <!--Comment-->
+        <!--Test processing instruction-->
+        <?xml-processing-instruction version="1.0"?>
+        <!--Test self-closing tag-->
+        <transaction/>
+        <!--Test namespace with xmlns url-->
+        <usg:treasury-main-account code="95"/>
+        <!--Test namespace without xmlns url-->
+        <sida:title>Tanzania 2020-2024</sida:title>
+    </iati-activity>
+</iati-activities>

--- a/src/tests/test_lakify.py
+++ b/src/tests/test_lakify.py
@@ -7,6 +7,7 @@ import pytest
 
 RECURSIVE_JSON_NEST_FILES = [
     ('basic'),
+    ('edgecase'),
 ]
 
 @pytest.mark.parametrize("filename", RECURSIVE_JSON_NEST_FILES)


### PR DESCRIPTION
Hi James,

I'll let you decide whether this test should pass or not. Just came up with an XML file that represents a series of edge cases and oddities I've seen before in IATI XML.

Strictly speaking, I think the only part of the expected output that could be considered a failure is the missing "Floating text." It's not against the standard to place text in locations like that, nor is it a part of the standard that any text placed as such would be expected to be read. But if we want this serialization to be a 1 for 1 representation, it is technically missing.

I've run some experiments, and the only way to actually fetch that text from an element with lxml is via the `element.itertext` function. It does not get returned by `element.text`, hence why it's missing here. Unfortunately, `itertext` also returns all the text of all subelements, but you can subset it just to the present tag. So long as a element doesn't contain a child with the same tag, code like this should work to fetch the floating inner-text.

```
inner_text = ''.join([inner_string.strip() for inner_string in element.itertext(tag=element.tag)])
```