### PR TITLE
Add inner text to lakify recursive_json_nest function

### DIFF
--- a/src/library/lakify.py
+++ b/src/library/lakify.py
@@ -21,26 +21,32 @@ def recursive_json_nest(element, output):
     element_dict = {'@{}'.format(e_key): element.get(e_key)
                     for e_key in element.keys()}
     element_tag = element.tag
-    inner_text = None
-    if element_tag is not etree.Comment and element_tag is not etree.PI:
-        inner_text = ''.join([inner_string.strip()
-                              for inner_string in element.itertext(tag=element_tag)])
-    elif element_tag is etree.Comment:
+    if element_tag is etree.Comment:
         element_tag = 'comment()'
     elif element_tag is etree.PI:
         element_tag = 'PI()'
+
     if element.text is not None and element.text.strip() != '':
         element_dict['text()'] = element.text
-    elif inner_text is not None and inner_text != '':
-        element_dict['text()'] = inner_text
-    elif element_tag == 'narrative':
+    else:
+        inner_text = None
+        if element_tag is not etree.Comment and element_tag is not etree.PI:
+            inner_text = ''.join([inner_string.strip()
+                                  for inner_string in element.itertext(tag=element_tag)])
+        if inner_text is not None and inner_text != '':
+            element_dict['text()'] = inner_text
+
+    if element_tag == 'narrative' and 'text()' not in element_dict:
         element_dict['text()'] = ''
+
     for e_child in element.getchildren():
         element_dict = recursive_json_nest(e_child, element_dict)
+
     if element_tag in output.keys():
         output[element_tag].append(element_dict)
     else:
         output[element_tag] = [element_dict]
+
     return output
 
 

--- a/src/library/lakify.py
+++ b/src/library/lakify.py
@@ -20,17 +20,23 @@ def clean_identifier(identifier):
 def recursive_json_nest(element, output):
     element_dict = {'@{}'.format(e_key): element.get(e_key)
                     for e_key in element.keys()}
+    element_tag = element.tag
+    inner_text = None
+    if element_tag is not etree.Comment and element_tag is not etree.PI:
+        inner_text = ''.join([inner_string.strip()
+                              for inner_string in element.itertext(tag=element_tag)])
+    elif element_tag is etree.Comment:
+        element_tag = 'comment()'
+    elif element_tag is etree.PI:
+        element_tag = 'PI()'
     if element.text is not None and element.text.strip() != '':
         element_dict['text()'] = element.text
-    elif element.tag == 'narrative':
+    elif inner_text is not None and inner_text != '':
+        element_dict['text()'] = inner_text
+    elif element_tag == 'narrative':
         element_dict['text()'] = ''
     for e_child in element.getchildren():
         element_dict = recursive_json_nest(e_child, element_dict)
-    element_tag = element.tag
-    if element_tag is etree.Comment:
-        element_tag = 'comment()'
-    if element_tag is etree.PI:
-        element_tag = 'PI()'
     if element_tag in output.keys():
         output[element_tag].append(element_dict)
     else:

--- a/src/tests/fixtures_lakify_recursive_json_nest/edgecase.expected.json
+++ b/src/tests/fixtures_lakify_recursive_json_nest/edgecase.expected.json
@@ -43,6 +43,7 @@
           "text()": "Tanzania 2020-2024"
         }
       ],
+      "text()": "Floating text",
       "transaction": [
         {}
       ],

--- a/src/tests/fixtures_lakify_recursive_json_nest/edgecase.expected.json
+++ b/src/tests/fixtures_lakify_recursive_json_nest/edgecase.expected.json
@@ -14,6 +14,9 @@
           "text()": "Test blank attribute"
         },
         {
+          "text()": "Text blank narrative"
+        },
+        {
           "text()": "Test comment"
         },
         {
@@ -44,6 +47,15 @@
         }
       ],
       "text()": "Floating text",
+      "title": [
+        {
+          "narrative": [
+            {
+              "text()": ""
+            }
+          ]
+        }
+      ],
       "transaction": [
         {}
       ],

--- a/src/tests/fixtures_lakify_recursive_json_nest/edgecase.input.xml
+++ b/src/tests/fixtures_lakify_recursive_json_nest/edgecase.input.xml
@@ -4,6 +4,10 @@
         Floating text
         <!--Test blank attribute-->
         <iati-identifier attribute=''>ACT-1</iati-identifier>
+        <!--Text blank narrative-->
+        <title>
+            <narrative></narrative>
+        </title>
         <!--Test comment-->
         <!--Comment-->
         <!--Test processing instruction-->


### PR DESCRIPTION
Fix for https://github.com/IATI/refresher/issues/291

Reconfigure recursive_json_nest function to check for inner text even if an element has children. Also add test for blank narrative, as that is explicitly written into the function to write a blank text() attribute for narrative tags.