### PR TITLE
Update memory allocation and container parallelisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,6 @@ Service Loop (when container starts)
 
 - `main()` - Flattens XML into a flat JSON document, then stores it in the database (`document.flattened_activities`) in JSONB format.
 
-Used to use the [iati-flattener service](https://github.com/IATI/iati-flattener),  but now it does it using a Python class it the same process.
-
 ## Logic
 
 - `main()`

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -1,3 +1,4 @@
+---
 name: '#NAME#-#ENVIRONMENT#' # Name of the container group
 apiVersion: '2021-10-01'
 location: 'uksouth'
@@ -18,7 +19,7 @@ properties: # Properties of container group
       properties: # Properties of an instance
         resources: # Resource requirements of the instance
           requests:
-            memoryInGB: 3.5
+            memoryInGB: 1.8  # 30 day max as of June 2026 was 1.3
             cpu: 0.5
         image: '#IMAGE_NAME#' # Container image used to create the instance
         command:
@@ -77,7 +78,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 3.5
+            memoryInGB: 1.2  # 30 day max as of June 2026 was 0.7
             cpu: 0.1
         image: '#IMAGE_NAME#'
         command:
@@ -136,7 +137,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 1.1
+            memoryInGB: 1  # 30 day max as of June 2026 was 0.6
             cpu: 0.1
         image: '#IMAGE_NAME#'
         command:
@@ -197,7 +198,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 3.5
+            memoryInGB: 2.6  # 30 day max as of June 2026 was 2
             cpu: 0.1
         image: '#IMAGE_NAME#'
         command:
@@ -252,7 +253,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 0.8
+            memoryInGB: 1.4  # 30 day max as of June 2026 unknown, crashing v. occasionally at 0.9
             cpu: 0.1
         image: '#IMAGE_NAME#'
         command:
@@ -299,7 +300,7 @@ properties: # Properties of container group
       properties:
         resources:
           requests:
-            memoryInGB: 3
+            memoryInGB: 3.8  # 30 day max as of June 2026 was unknown, crashing at cap 3
             cpu: 1
         image: '#IMAGE_NAME#'
         command:
@@ -357,7 +358,7 @@ properties: # Properties of container group
         resources:
           requests:
             cpu: 0.1
-            memoryInGB: 0.6
+            memoryInGB: 0.3  # 30 day max as of June 2026 was 0.05
   ipAddress:
     type: "public"
     dnsNameLabel: "#NAME#-#ENVIRONMENT#"

--- a/src/constants/config.py
+++ b/src/constants/config.py
@@ -115,7 +115,7 @@ def load_config_from_env():
         ),
         LAKIFY=dict(
             # Number of parallel processes to run the lakify loop with
-            PARALLEL_PROCESSES=10,
+            PARALLEL_PROCESSES=3,
             PROM_PORT=9095,
             PROM_METRIC_DEFS=[
                 ("datasets_to_lakify", "The number of datasets that need lakifying"),


### PR DESCRIPTION
The memory usage of some containers scales with document size, because there is no streaming, and in June 2026 a set of four large documents ended up repeatedly crashing the workers in the Solrize stage. This PR and some alterations to GitHub env vars:
* Reduces the parallelisation in the Lakify and Solrize stages
* Adjusts the max memory for each container to its observed maximum over the past 30 days. This gives Lakify and Solrize more (in conjunction with reducing parallelisation), while also reducing container group consmption to 12 Gb, which should reduce cost per month.